### PR TITLE
chore(ci): tagging via git command

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           release-type: rust
-          skip-github-release: false
+          skip-github-release: true
 
       - name: Tagging with git command
         if: steps.releaes-please.outputs.release_created == 'true'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,3 +25,13 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           release-type: rust
           skip-github-release: false
+
+      - name: Tagging with git command
+        if: steps.releaes-please.outputs.release_created == 'true'
+        run: |
+          echo "Tagging version: v${{ steps.releaes-please.outputs.major }}.${{ steps.releaes-please.outputs.minor }}.${{ steps.releaes-please.outputs.patch }}"
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git remote add gh-token "https://${{ steps.app-token.outputs.token }}@github.com/googleapis/release-please-action.git"
+          git tag v${{ steps.releaes-please.outputs.major }}.${{ steps.releaes-please.outputs.minor }}.${{ steps.releaes-please.outputs.patch }}
+          git push origin v${{ steps.releaes-please.outputs.major }}.${{ steps.releaes-please.outputs.minor }}.${{ steps.releaes-please.outputs.patch }}


### PR DESCRIPTION
release-please-action's `skip-github-release` creates both a tag and a GitHub release and that conflicts with cargo-dist.

So we should only create a tag in release-please workflow.